### PR TITLE
Add Python 3.10 support

### DIFF
--- a/x16r_module.c
+++ b/x16r_module.c
@@ -1,5 +1,7 @@
 #include <Python.h>
 
+#define PY_SSIZE_T_CLEAN
+
 #include "x16r.h"
 
 static PyObject *x16r_getpowhash(PyObject *self, PyObject *args)

--- a/x16r_module.c
+++ b/x16r_module.c
@@ -1,6 +1,6 @@
-#include <Python.h>
-
 #define PY_SSIZE_T_CLEAN
+
+#include <Python.h>
 
 #include "x16r.h"
 


### PR DESCRIPTION
PEP-0353 is required for Python  >=3.10 to work. For more information: https://peps.python.org/pep-0353